### PR TITLE
Fix bit/byte confusion when computing decoding masks.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /MODULE.bazel.lock
 /Cargo.lock
 /target
+/.idea

--- a/vu128/vu128.rs
+++ b/vu128/vu128.rs
@@ -363,7 +363,7 @@ pub fn decode_u64(buf: &[u8; 9]) -> (u64, usize) {
 
 	const LEN_MASK: u8 = 0b111;
 	let len = buf[0] & 0x0F;
-	let mask = u64::MAX >> ((len & LEN_MASK) ^ LEN_MASK);
+	let mask = u64::MAX >> (((len & LEN_MASK) ^ LEN_MASK) * 8);
 	(value & mask, (len + 2) as usize)
 }
 
@@ -401,7 +401,7 @@ pub fn decode_u128(buf: &[u8; 17]) -> (u128, usize) {
 	});
 	const LEN_MASK: u8 = 0b1111;
 	let len = buf[0] & 0x0F;
-	let mask = u128::MAX >> ((len & LEN_MASK) ^ LEN_MASK);
+	let mask = u128::MAX >> (((len & LEN_MASK) ^ LEN_MASK) * 8);
 	(value & mask, (len + 2) as usize)
 }
 

--- a/vu128/vu128_test.rs
+++ b/vu128/vu128_test.rs
@@ -134,11 +134,14 @@ fn test_encode_u32() {
 #[test]
 fn test_decode_u32() {
 	for (expect, encoded_value) in U32_TEST_CASES {
-		let mut buf = [0u8; 5];
-		(&mut buf[0..encoded_value.len()]).copy_from_slice(encoded_value);
-		let got = vu128::decode_u32(&buf);
-		let expect = (*expect, encoded_value.len());
-		assert_expected!(decode_u32, encoded_value, expect, got);
+		for padding in [0u8, 255] {
+			let mut buf = [0u8; 5];
+			(&mut buf[0..encoded_value.len()]).copy_from_slice(encoded_value);
+			buf[encoded_value.len()..].fill(padding);
+			let got = vu128::decode_u32(&buf);
+			let expect = (*expect, encoded_value.len());
+			assert_expected!(decode_u32, encoded_value, expect, got);
+		}
 	}
 }
 
@@ -153,12 +156,15 @@ fn test_encode_u64() {
 
 #[test]
 fn test_decode_u64() {
-	for (expect, encoded_value) in U64_TEST_CASES {
-		let mut buf = [0u8; 9];
-		(&mut buf[0..encoded_value.len()]).copy_from_slice(encoded_value);
-		let got = vu128::decode_u64(&buf);
-		let expect = (*expect, encoded_value.len());
-		assert_expected!(decode_u64, encoded_value, expect, got);
+	for padding in [0u8, 255] {
+		for (expect, encoded_value) in U64_TEST_CASES {
+			let mut buf = [0u8; 9];
+			(&mut buf[0..encoded_value.len()]).copy_from_slice(encoded_value);
+			buf[encoded_value.len()..].fill(padding);
+			let got = vu128::decode_u64(&buf);
+			let expect = (*expect, encoded_value.len());
+			assert_expected!(decode_u64, encoded_value, expect, got);
+		}
 	}
 }
 
@@ -180,19 +186,23 @@ fn test_encode_u128() {
 
 #[test]
 fn test_decode_u128() {
-	for (expect, encoded_value) in U32_TEST_CASES {
-		let mut buf = [0u8; 17];
-		(&mut buf[0..encoded_value.len()]).copy_from_slice(encoded_value);
-		let got = vu128::decode_u128(&buf);
-		let expect = (*expect as u128, encoded_value.len());
-		assert_expected!(decode_u128, encoded_value, expect, got);
-	}
-	for (expect, encoded_value) in U64_TEST_CASES {
-		let mut buf = [0u8; 17];
-		(&mut buf[0..encoded_value.len()]).copy_from_slice(encoded_value);
-		let got = vu128::decode_u128(&buf);
-		let expect = (*expect as u128, encoded_value.len());
-		assert_expected!(decode_u128, encoded_value, expect, got);
+	for padding in [0u8, 255] {
+		for (expect, encoded_value) in U32_TEST_CASES {
+			let mut buf = [0u8; 17];
+			(&mut buf[0..encoded_value.len()]).copy_from_slice(encoded_value);
+			buf[encoded_value.len()..].fill(padding);
+			let got = vu128::decode_u128(&buf);
+			let expect = (*expect as u128, encoded_value.len());
+			assert_expected!(decode_u128, encoded_value, expect, got);
+		}
+		for (expect, encoded_value) in U64_TEST_CASES {
+			let mut buf = [0u8; 17];
+			(&mut buf[0..encoded_value.len()]).copy_from_slice(encoded_value);
+			buf[encoded_value.len()..].fill(padding);
+			let got = vu128::decode_u128(&buf);
+			let expect = (*expect as u128, encoded_value.len());
+			assert_expected!(decode_u128, encoded_value, expect, got);
+		}
 	}
 }
 


### PR DESCRIPTION
This PR fixes an issue computing the decoding mask for numbers greater than 2^28. The mask should be shifted to include a certain number of bytes, not bits. This includes unrelated bits after the current encoded value in the output. I've included test cases to verify these bits are ignored.